### PR TITLE
Add checks to make sure that we don't keep applying silences when a n…

### DIFF
--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -14,4 +14,10 @@ var (
 
 	// ErrMissingNode is returned when the node a label is deleted from is not found
 	ErrMissingNode = errors.New("missing node")
+
+	// ErrNodeNotReady is returned when the node is not ready
+	ErrNodeNotReady = errors.New("node not ready")
+
+	// ErrNodeUnschedulable is returned when the node is unschedulable
+	ErrNodeUnschedulable = errors.New("node unschedulable")
 )


### PR DESCRIPTION
Adds checks prior to creating a silence to see whether a node is already `NotReady` or `Unschedulable`